### PR TITLE
Variables omitted null values by default. Add directive to keep null value.

### DIFF
--- a/lib/generator/print_helpers.dart
+++ b/lib/generator/print_helpers.dart
@@ -212,8 +212,8 @@ Spec fragmentClassDefinitionToSpec(FragmentClassDefinition definition) {
 Spec generateArgumentClassSpec(QueryDefinition definition) {
   return Class(
     (b) => b
-      ..annotations
-          .add(CodeExpression(Code('JsonSerializable(explicitToJson: true)')))
+      ..annotations.add(CodeExpression(
+          Code('JsonSerializable(explicitToJson: true, includeIfNull: false)')))
       ..name = '${definition.className}Arguments'
       ..extend = refer('JsonSerializable')
       ..mixins.add(refer('EquatableMixin'))

--- a/lib/visitor/generator_visitor.dart
+++ b/lib/visitor/generator_visitor.dart
@@ -197,6 +197,14 @@ class GeneratorVisitor extends RecursiveVisitor {
       }
     }
 
+    final hasNullableDirective = node.directives
+        .any((directive) => directive.name.value == 'includeNull');
+
+    /// Allow nullable value in variables
+    if (hasNullableDirective) {
+      jsonKeyAnnotation['includeIfNull'] = 'true';
+    }
+
     final inputName = QueryInputName(name: node.variable.name.value);
 
     if (inputName.namePrintable != inputName.name) {

--- a/test/generator/print_helpers_test.dart
+++ b/test/generator/print_helpers_test.dart
@@ -529,7 +529,7 @@ import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 part 'test_query.graphql.g.dart';
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 
@@ -588,7 +588,8 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
 
       final str = specToString(generateArgumentClassSpec(definition));
 
-      expect(str, '''@JsonSerializable(explicitToJson: true)
+      expect(
+          str, '''@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class TestQueryArguments extends JsonSerializable with EquatableMixin {
   TestQueryArguments({this.name});
 

--- a/test/query_generator/ast_schema/multiple_schema_mappint_test.dart
+++ b/test/query_generator/ast_schema/multiple_schema_mappint_test.dart
@@ -495,7 +495,7 @@ enum NotificationType {
   artemisUnknown,
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class BrowseRepositoriesArguments extends JsonSerializable with EquatableMixin {
   BrowseRepositoriesArguments({this.notificationTypes});
 

--- a/test/query_generator/deprecated/deprecated_input_object_field_test.dart
+++ b/test/query_generator/deprecated/deprecated_input_object_field_test.dart
@@ -157,7 +157,7 @@ class Input extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$InputToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({required this.input});
 

--- a/test/query_generator/enums/input_enum_list_test.dart
+++ b/test/query_generator/enums/input_enum_list_test.dart
@@ -165,7 +165,7 @@ enum ArticleType {
   artemisUnknown,
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class BrowseArticlesArguments extends JsonSerializable with EquatableMixin {
   BrowseArticlesArguments({this.article_type_in});
 

--- a/test/query_generator/enums/input_enum_test.dart
+++ b/test/query_generator/enums/input_enum_test.dart
@@ -221,7 +221,7 @@ enum OtherEnum {
   artemisUnknown,
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({required this.$id, required this.input, required this.o});
 

--- a/test/query_generator/fragments/fragment_multiple_queries_test.dart
+++ b/test/query_generator/fragments/fragment_multiple_queries_test.dart
@@ -250,7 +250,7 @@ class GetAllPokemons$Query extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$GetAllPokemons$QueryToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class GetPokemonArguments extends JsonSerializable with EquatableMixin {
   GetPokemonArguments({required this.name});
 
@@ -336,7 +336,7 @@ class GetPokemonQuery
       GetPokemon$Query.fromJson(json);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class GetAllPokemonsArguments extends JsonSerializable with EquatableMixin {
   GetAllPokemonsArguments({required this.first});
 

--- a/test/query_generator/fragments/fragments_multiple_test.dart
+++ b/test/query_generator/fragments/fragments_multiple_test.dart
@@ -319,7 +319,7 @@ class PaginationInput extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$PaginationInputToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class VoyagesDataArguments extends JsonSerializable with EquatableMixin {
   VoyagesDataArguments({required this.input});
 

--- a/test/query_generator/multiple_operations_per_file_test.dart
+++ b/test/query_generator/multiple_operations_per_file_test.dart
@@ -247,7 +247,7 @@ class QueData$Query extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$QueData$QueryToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class MutDataArguments extends JsonSerializable with EquatableMixin {
   MutDataArguments({required this.input});
 
@@ -316,7 +316,7 @@ class MutDataMutation extends GraphQLQuery<MutData$Mutation, MutDataArguments> {
       MutData$Mutation.fromJson(json);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class QueDataArguments extends JsonSerializable with EquatableMixin {
   QueDataArguments({required this.intsNonNullable, this.stringNullable});
 

--- a/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/complex_input_objects_test.dart
@@ -194,7 +194,7 @@ enum MyEnum {
   artemisUnknown,
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({required this.filter});
 

--- a/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/custom_scalars_on_input_objects_test.dart
@@ -199,7 +199,7 @@ class Input extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$InputToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({required this.input, this.previousId, this.listIds});
 

--- a/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
+++ b/test/query_generator/mutations_and_inputs/filter_input_objects_test.dart
@@ -181,7 +181,7 @@ class SubInput extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$SubInputToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({required this.input});
 

--- a/test/query_generator/mutations_and_inputs/input_duplication_test.dart
+++ b/test/query_generator/mutations_and_inputs/input_duplication_test.dart
@@ -234,7 +234,7 @@ class CustomList$Mutation extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$CustomList$MutationToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({required this.input});
 
@@ -303,7 +303,7 @@ class CustomMutation extends GraphQLQuery<Custom$Mutation, CustomArguments> {
       Custom$Mutation.fromJson(json);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomListArguments extends JsonSerializable with EquatableMixin {
   CustomListArguments({required this.input});
 

--- a/test/query_generator/mutations_and_inputs/mutations_test.dart
+++ b/test/query_generator/mutations_and_inputs/mutations_test.dart
@@ -267,7 +267,7 @@ class $Input extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$$InputToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class CustomArguments extends JsonSerializable with EquatableMixin {
   CustomArguments({required this.input});
 
@@ -337,7 +337,7 @@ class CustomMutation
       Custom$MutationRoot.fromJson(json);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class $customArguments extends JsonSerializable with EquatableMixin {
   $customArguments({required this.input});
 

--- a/test/query_generator/mutations_and_inputs/non_nullable_list_inputs_test.dart
+++ b/test/query_generator/mutations_and_inputs/non_nullable_list_inputs_test.dart
@@ -141,7 +141,7 @@ class SomeQuery$Query extends JsonSerializable with EquatableMixin {
   Map<String, dynamic> toJson() => _$SomeQuery$QueryToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments(
       {this.i,

--- a/test/query_generator/naming/casing_conversion_test.dart
+++ b/test/query_generator/naming/casing_conversion_test.dart
@@ -301,7 +301,7 @@ enum MyEnum {
   artemisUnknown,
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
 class SomeQueryArguments extends JsonSerializable with EquatableMixin {
   SomeQueryArguments({required this.filter});
 


### PR DESCRIPTION
Added `@includeNull` directive in the schema. All input variables now omitted null values by default.